### PR TITLE
Added a TypeScript Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ This repository has several live code examples for various JavaScript integratio
 * [Browserify](./browserify-and-npm) - Bundling TrackJS with your app bundle using Browserify
 * [Bower](./bower-and-gulp) - Uses Gulp to bundle TrackJS, other bower components and your application
 * [JSPM and Babel](./jspm-with-babel) - Shows how to use TrackJS with UMD and ES6 
+* [TypeScript](./typescript) - Use TrackJS TypeScript definitions
+ 

--- a/typescript/.gitignore
+++ b/typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,21 @@
+trackjs-integration-typescript
+================================
+
+An example of using the TrackJS NPM package with TypeScript
+
+## Running the example
+
+Download the dependencies.
+
+```bash
+npm install
+```
+
+The `example.ts` contains the example TypeScript calls. Compile to JavaScript with:
+
+```bash
+npm run typescript
+```
+
+The resulting JavaScript will be placed in the `dist` directory.
+

--- a/typescript/example.ts
+++ b/typescript/example.ts
@@ -1,0 +1,24 @@
+/// <reference path="./node_modules/trackjs/tracker.d.ts" />
+
+/**
+ * Setup for the Tracker script before it has loaded
+ */
+window._trackJs = {
+    token: "PUT_YOUR_TOKEN_HERE",
+    application: "YOUR_APPLICATION_KEY",
+    onError: function (payload) {
+        return true;
+    }
+}
+
+/**
+ * After the Tracker script tag has loaded, the trackJs
+ * static namespace is available for calls.  
+ */
+trackJs.addMetadata("accountId", "1234");
+trackJs.configure({
+    userId: "user@example.com",
+    sessionId: "session123"
+});
+
+

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "trackjs-integration-typescript",
+  "version": "1.0.0",
+  "description": "An example of using the TrackJS npm package with TypeScript",
+  "author": "TrackJS",
+  "repository": {
+		"type": "git",
+		"url": "git://github.com/TrackJs/js-integrations/js-integrations.git"
+	},
+  "dependencies": {
+    "trackjs": "^2.4.0"
+  },
+  "devDependencies": {
+    "typescript": "^1.8.10"
+  },
+  "scripts": {
+    "typescript": "node_modules/typescript/bin/tsc ./example.ts --outDir dist/ --sourcemap"
+  }
+}


### PR DESCRIPTION
Based on the PR TypeScript definitions, added an example that shows how to use with TypeScript. This will only work after https://github.com/TrackJs/Tracker/pull/20 has been deployed.